### PR TITLE
Pagination

### DIFF
--- a/app/controllers/bucketlists_controller.rb
+++ b/app/controllers/bucketlists_controller.rb
@@ -3,7 +3,11 @@ class BucketlistsController < ApplicationController
 
   # GET /bucketlists
   def index
-    @bucketlists = @current_user.bucketlists.order(id: :desc)
+    @page = params[:page].to_i < 1 ? 1 : params[:page].to_i
+    @limit = params[:limit].to_i < 1 ? 20 : params[:limit].to_i
+    @offset = (@page - 1) * @limit
+    @bucketlists = @current_user.bucketlists.limit(@limit)
+                    .offset(@offset).order(:id)
 
     render json: @bucketlists
   end
@@ -40,8 +44,9 @@ class BucketlistsController < ApplicationController
   end
 
   private
-    # Only allow a trusted parameter "white list" through.
-    def bucketlist_params
-      params.permit(:name)
-    end
+
+  # Only allow a trusted parameter "white list" through.
+  def bucketlist_params
+    params.permit(:name, :page, :limit)
+  end
 end


### PR DESCRIPTION
Why: So user can view a subset of the bucketlist resource at a time
rather than going over a very long list if they have many bucketlists.

This change addresses the need by:
*Allowing the user to specify page and limit when making GET
/bucketlists request by permitting page and limit in params
*Updating the index method of the Bucketlist controller to limit the
bucketlists rendered using Activerecord#limit and #offset.

[Finishes #111680718]
